### PR TITLE
build_scripts: Update git clone URL for mbedtls

### DIFF
--- a/build_scripts/Repository Installs.txt
+++ b/build_scripts/Repository Installs.txt
@@ -35,7 +35,7 @@ mbed
 NOTES: mbed code is needed to build Trusted Firmware-A in BSP v1.0.5+
 
 Clone repository and check out branch:
-	$ git clone git://github.com/ARMmbed/mbedtls.git
+	$ git clone https://github.com/ARMmbed/mbedtls.git
 	$ cd mbedtls
 	$ git checkout mbedtls-2.16.3
 	$ cd ..


### PR DESCRIPTION
[GitHub not longer supports 'git://' URLs](1)

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git