### PR TITLE
build_scripts: Support symlinked toolchains

### DIFF
--- a/build_scripts/build_common.sh
+++ b/build_scripts/build_common.sh
@@ -25,7 +25,7 @@ select_toolchain() {
 
   # Look for Poky (SDK) Toolchains
   if [ -e /opt/poky ] ; then
-    array_poky=( $(find /opt/poky -mindepth 1 -maxdepth 1 -type d))
+    array_poky=( $(find -L /opt/poky -mindepth 1 -maxdepth 1 -type d))
   fi
   array_poky_size=${#array_poky[@]}
   if [ "$array_poky_size" != "0" ] ; then
@@ -42,7 +42,7 @@ select_toolchain() {
 
   # ARM Toolchains
   if [ -e /opt/arm ] ; then
-    array_arm=( $(find /opt/arm -mindepth 1 -maxdepth 1 -type d))
+    array_arm=( $(find -L /opt/arm -mindepth 1 -maxdepth 1 -type d))
   fi
   array_arm_size=${#array_arm[@]}
   if [ "$array_arm_size" != "0" ] ; then
@@ -60,7 +60,7 @@ select_toolchain() {
 
   # Linaro Toolchains
   if [ -e /opt/linaro ] ; then
-    array_linaro=( $(find /opt/linaro -mindepth 1 -maxdepth 1 -type d))
+    array_linaro=( $(find -L /opt/linaro -mindepth 1 -maxdepth 1 -type d))
   fi
   array_linaro_size=${#array_linaro[@]}
   if [ "$array_linaro_size" != "0" ] ; then


### PR DESCRIPTION
By default, `find ... -type d` will ignore symlinks to directories unless the `-L` ("Follow symbolic links") argument is given.

Users may want to install a toolchain somewhere in their system other than the directories where these build scripts search (`/opt/arm`, `/opt/linaro`, etc) so we should support symlinks to toolchain directories in these paths.